### PR TITLE
Allow creation of nested Options objects

### DIFF
--- a/optionsfactory/_utils.py
+++ b/optionsfactory/_utils.py
@@ -35,13 +35,36 @@ def _options_table_string(options):
 
     # Header
     result = (
-        "\nOptions\n=======\n" + formatstring.format("Name", "Value") + "-" * 80 + "\n"
+        "\nOptions\n=======\n" + formatstring.format("Name", "Value") + "=" * 80 + "\n"
     )
 
-    # Row for each value
-    for name, value in sorted(options.items()):
-        valuestring = str(value)
-        if options.is_default(name):
-            valuestring = defaultformat.format(valuestring)
-        result += formatstring.format(name, valuestring)
+    def _options_table_subsection(options, subsection_name):
+        result = ""
+
+        # subsection header
+        if subsection_name is not None:
+            result += (
+                "-" * 80 + "\n" + "{:<80}\n".format(subsection_name) + "-" * 80 + "\n"
+            )
+
+        # Row for each value that is not a subsection
+        for name, value in sorted(options.items()):
+            if name in options.get_subsections():
+                continue
+            valuestring = str(value)
+            if options.is_default(name):
+                valuestring = defaultformat.format(valuestring)
+            result += formatstring.format(name, valuestring)
+
+        for name in options.get_subsections():
+            result += _options_table_subsection(
+                options[name],
+                f"{str(subsection_name) + ':' if subsection_name is not None else ''}"
+                f"{name}",
+            )
+
+        return result
+
+    result += _options_table_subsection(options, None)
+
     return result

--- a/optionsfactory/optionsfactory.py
+++ b/optionsfactory/optionsfactory.py
@@ -391,6 +391,10 @@ class OptionsFactory:
             for key in self.__defaults:
                 value = self[key]
                 string += f"{key}: {value}"
+
+                # Using 'is True' here means we only append ' (default)' to options, not
+                # sections: if 'key' is a section then self.is_default(key) will return
+                # a dict
                 if self.is_default(key) is True:
                     string += " (default)"
                 string += ", "
@@ -523,6 +527,10 @@ class OptionsFactory:
             string = "{"
             for key in self.__data:
                 string += f"{key}: {self[key]}"
+
+                # Using 'is True' here means we only append ' (default)' to options, not
+                # sections: if 'key' is a section then self.is_default(key) will return
+                # a dict
                 if self.is_default(key) is True:
                     string += " (default)"
                 string += ", "

--- a/optionsfactory/optionsfactory.py
+++ b/optionsfactory/optionsfactory.py
@@ -240,6 +240,32 @@ class OptionsFactory:
             """
             return _options_table_string(self)
 
+        def to_dict(self, with_defaults=True):
+            """Convert the MutableOptions object to a dict
+
+            Parameters
+            ----------
+            with_defaults : bool, default True
+                Include the default values in the returned dict?
+            """
+            if with_defaults:
+                return {
+                    key: value
+                    if not isinstance(value, OptionsFactory.MutableOptions)
+                    else value.to_dict(with_defaults)
+                    for key, value in self.items()
+                }
+            else:
+                return {
+                    key: value
+                    if not isinstance(value, OptionsFactory.MutableOptions)
+                    else value.to_dict(with_defaults)
+                    for key, value in self.items()
+                    # Use 'is not True' so we include subsections, for which
+                    # self.is_default(key) returns a dict
+                    if self.is_default(key) is not True
+                }
+
         def to_yaml(self, file_like, with_defaults=False):
             """Save the options to a YAML file
 
@@ -254,10 +280,7 @@ class OptionsFactory:
             """
             import yaml
 
-            if with_defaults:
-                return yaml.dump(dict(self), file_like)
-            else:
-                return yaml.dump(self.__data, file_like)
+            return yaml.dump(self.to_dict(with_defaults), file_like)
 
         def get_subsections(self):
             """
@@ -439,6 +462,32 @@ class OptionsFactory:
             """
             return _options_table_string(self)
 
+        def to_dict(self, with_defaults=True):
+            """Convert the MutableOptions object to a dict
+
+            Parameters
+            ----------
+            with_defaults : bool, default True
+                Include the default values in the returned dict?
+            """
+            if with_defaults:
+                return {
+                    key: value
+                    if not isinstance(value, OptionsFactory.Options)
+                    else value.to_dict(with_defaults)
+                    for key, value in self.items()
+                }
+            else:
+                return {
+                    key: value
+                    if not isinstance(value, OptionsFactory.Options)
+                    else value.to_dict(with_defaults)
+                    for key, value in self.items()
+                    # Use 'is not True' so we include subsections, for which
+                    # self.is_default(key) returns a dict
+                    if self.is_default(key) is not True
+                }
+
         def to_yaml(self, file_like, with_defaults=False):
             """Save the options to a YAML file
 
@@ -453,17 +502,7 @@ class OptionsFactory:
             """
             import yaml
 
-            if with_defaults:
-                return yaml.dump(dict(self), file_like)
-            else:
-                return yaml.dump(
-                    {
-                        key: value
-                        for key, value in self.items()
-                        if not self.is_default(key)
-                    },
-                    file_like,
-                )
+            return yaml.dump(self.to_dict(with_defaults), file_like)
 
         def get_subsections(self):
             """

--- a/optionsfactory/optionsfactory.py
+++ b/optionsfactory/optionsfactory.py
@@ -181,11 +181,12 @@ class OptionsFactory:
                 key: _checked(value, meta=self.__defaults[key], name=key)
                 for key, value in data.items()
             }
+            self.__doc = {key: value.doc for key, value in self.__defaults.items()}
             self.__cache = {}
 
         @property
         def doc(self):
-            return {key: deepcopy(value.doc) for key, value in self.__defaults.items()}
+            return self.__doc
 
         def as_table(self):
             """Return a string with a formatted table of the settings

--- a/optionsfactory/optionsfactory.py
+++ b/optionsfactory/optionsfactory.py
@@ -308,13 +308,14 @@ class OptionsFactory:
             return len(self.__defaults)
 
         def __iter__(self):
-            return iter({key: value for key, value in self.items()})
+            return iter(self.keys())
 
         def keys(self):
-            return [key for key in self.__defaults]
+            return self.__defaults.keys()
 
         def values(self):
-            return [self[key] for key in self.__defaults]
+            for key in self:
+                yield self[key]
 
         def items(self):
             return zip(self.keys(), self.values())
@@ -421,13 +422,14 @@ class OptionsFactory:
             return len(self.__data)
 
         def __iter__(self):
-            return iter(deepcopy(self.__data))
+            return iter(self.keys())
 
         def keys(self):
-            return [key for key in self]
+            return self.__data.keys()
 
         def values(self):
-            return [deepcopy(v) for v in self.__data.values()]
+            for v in self.__data.values():
+                yield deepcopy(v)
 
         def items(self):
             return zip(self.keys(), self.values())

--- a/optionsfactory/optionsfactory.py
+++ b/optionsfactory/optionsfactory.py
@@ -57,7 +57,12 @@ class OptionsFactory:
 
         # Add defaults from *args
         for a in args:
-            for key, value in a.items():
+            if not isinstance(a, OptionsFactory):
+                raise ValueError(
+                    f"Positional arguments to OptionsFactory.__init__() must be "
+                    f"OptionsFactory instances, was passed a {type(a)}"
+                )
+            for key, value in a.defaults.items():
                 if key in self.__defaults:
                     if value != self.__defaults[key]:
                         raise ValueError(

--- a/optionsfactory/tests/test_mutableoptions.py
+++ b/optionsfactory/tests/test_mutableoptions.py
@@ -8,7 +8,7 @@ from ..checks import is_positive
 from .test_options import as_table_test_str
 
 
-class TestOptions:
+class TestMutableOptions:
     def test_defaults(self):
         factory = MutableOptionsFactory(
             a=1,

--- a/optionsfactory/tests/test_mutableoptions.py
+++ b/optionsfactory/tests/test_mutableoptions.py
@@ -202,7 +202,6 @@ class TestOptions:
             ),
         )
 
-        # test default values
         opts = factory.create({"a": 4, "b": 5, "f": 3.0, "g": 13, "z": 17})
 
         assert opts.a == 4
@@ -532,7 +531,6 @@ class TestMutableOptionsFactoryImmutable:
             ),
         )
 
-        # test default values
         opts = factory.create_immutable({"a": 4, "b": 5, "f": 3.0, "g": 13, "z": 17})
 
         assert opts.a == 4

--- a/optionsfactory/tests/test_mutableoptions.py
+++ b/optionsfactory/tests/test_mutableoptions.py
@@ -409,6 +409,113 @@ class TestMutableOptions:
         with pytest.raises(ValueError, match="Circular definition"):
             opts.b
 
+    def test_add_defaults(self):
+        subfactory = MutableOptionsFactory(
+            d=WithMeta(4, doc="option d1"),
+            e=WithMeta(5, doc="option e1"),
+            f=WithMeta(6, doc="option f1"),
+        )
+        factory = MutableOptionsFactory(
+            a=WithMeta(1, doc="option a1"),
+            b=WithMeta(2, doc="option b1"),
+            c=WithMeta(3, doc="option c1"),
+            subsection=subfactory,
+        )
+
+        factory2 = factory.add(
+            b=12,
+            c=WithMeta(13, doc="option c2"),
+            g=17,
+            subsection={"d": 14, "e": WithMeta(15, doc="option e2"), "h": 18},
+            subsection2=MutableOptionsFactory(i=WithMeta(19, doc="option i2")),
+        )
+
+        opts = factory2.create({})
+
+        assert opts.a == 1
+        assert opts.b == 12
+        assert opts.c == 13
+        assert opts.subsection.d == 14
+        assert opts.subsection.e == 15
+        assert opts.subsection.f == 6
+        assert opts.g == 17
+        assert opts.subsection.h == 18
+        assert opts.subsection2.i == 19
+
+        assert opts.doc["a"] == "option a1"
+        assert opts.doc["b"] == "option b1"
+        assert opts.doc["c"] == "option c2"
+        assert opts.doc["subsection"]["d"] == "option d1"
+        assert opts.doc["subsection"]["e"] == "option e2"
+        assert opts.doc["subsection"]["f"] == "option f1"
+        assert opts.doc["g"] is None
+        assert opts.doc["subsection"]["h"] is None
+        assert opts.doc["subsection2"]["i"] == "option i2"
+
+        with pytest.raises(ValueError, match="Passing an OptionsFactory"):
+            factory.add(a=MutableOptionsFactory(j=2))
+
+        with pytest.raises(ValueError, match="Updating the section"):
+            factory.add(subsection=MutableOptionsFactory(d=14, e=15, f=16))
+
+    def test_add_initialise(self):
+        subfactory = MutableOptionsFactory(
+            d=WithMeta(4, doc="option d1"),
+            e=WithMeta(5, doc="option e1"),
+            f=WithMeta(6, doc="option f1"),
+        )
+        factory = MutableOptionsFactory(
+            a=WithMeta(1, doc="option a1"),
+            b=WithMeta(2, doc="option b1"),
+            c=WithMeta(3, doc="option c1"),
+            subsection=subfactory,
+        )
+
+        factory2 = factory.add(
+            b=12,
+            c=WithMeta(13, doc="option c2"),
+            g=17,
+            subsection={"d": 14, "e": WithMeta(15, doc="option e2"), "h": 18},
+            subsection2=MutableOptionsFactory(i=WithMeta(19, doc="option i2")),
+        )
+
+        opts = factory2.create(
+            {
+                "a": 21,
+                "b": 22,
+                "c": 23,
+                "subsection": {"d": 24, "e": 25, "f": 26, "h": 27},
+                "g": 28,
+                "subsection2": {"i": 29},
+            }
+        )
+
+        assert opts.a == 21
+        assert opts.b == 22
+        assert opts.c == 23
+        assert opts.subsection.d == 24
+        assert opts.subsection.e == 25
+        assert opts.subsection.f == 26
+        assert opts.g == 28
+        assert opts.subsection.h == 27
+        assert opts.subsection2.i == 29
+
+        assert opts.doc["a"] == "option a1"
+        assert opts.doc["b"] == "option b1"
+        assert opts.doc["c"] == "option c2"
+        assert opts.doc["subsection"]["d"] == "option d1"
+        assert opts.doc["subsection"]["e"] == "option e2"
+        assert opts.doc["subsection"]["f"] == "option f1"
+        assert opts.doc["g"] is None
+        assert opts.doc["subsection"]["h"] is None
+        assert opts.doc["subsection2"]["i"] == "option i2"
+
+        with pytest.raises(ValueError, match="Passing an OptionsFactory"):
+            factory.add(a=MutableOptionsFactory(j=2))
+
+        with pytest.raises(ValueError, match="Updating the section"):
+            factory.add(subsection=MutableOptionsFactory(d=14, e=15, f=16))
+
     def test_as_table(self):
         factory = MutableOptionsFactory(a=1, b=2)
         opts = factory.create({"b": 3})
@@ -943,6 +1050,113 @@ class TestMutableOptionsFactoryImmutable:
         assert sorted([k for k in opts]) == sorted(["a", "b"])
         assert sorted(opts.values()) == sorted([3, 3])
         assert sorted(opts.items()) == sorted([("a", 3), ("b", 3)])
+
+    def test_add_defaults(self):
+        subfactory = MutableOptionsFactory(
+            d=WithMeta(4, doc="option d1"),
+            e=WithMeta(5, doc="option e1"),
+            f=WithMeta(6, doc="option f1"),
+        )
+        factory = MutableOptionsFactory(
+            a=WithMeta(1, doc="option a1"),
+            b=WithMeta(2, doc="option b1"),
+            c=WithMeta(3, doc="option c1"),
+            subsection=subfactory,
+        )
+
+        factory2 = factory.add(
+            b=12,
+            c=WithMeta(13, doc="option c2"),
+            g=17,
+            subsection={"d": 14, "e": WithMeta(15, doc="option e2"), "h": 18},
+            subsection2=MutableOptionsFactory(i=WithMeta(19, doc="option i2")),
+        )
+
+        opts = factory2.create_immutable({})
+
+        assert opts.a == 1
+        assert opts.b == 12
+        assert opts.c == 13
+        assert opts.subsection.d == 14
+        assert opts.subsection.e == 15
+        assert opts.subsection.f == 6
+        assert opts.g == 17
+        assert opts.subsection.h == 18
+        assert opts.subsection2.i == 19
+
+        assert opts.doc["a"] == "option a1"
+        assert opts.doc["b"] == "option b1"
+        assert opts.doc["c"] == "option c2"
+        assert opts.doc["subsection"]["d"] == "option d1"
+        assert opts.doc["subsection"]["e"] == "option e2"
+        assert opts.doc["subsection"]["f"] == "option f1"
+        assert opts.doc["g"] is None
+        assert opts.doc["subsection"]["h"] is None
+        assert opts.doc["subsection2"]["i"] == "option i2"
+
+        with pytest.raises(ValueError, match="Passing an OptionsFactory"):
+            factory.add(a=MutableOptionsFactory(j=2))
+
+        with pytest.raises(ValueError, match="Updating the section"):
+            factory.add(subsection=MutableOptionsFactory(d=14, e=15, f=16))
+
+    def test_add_initialise(self):
+        subfactory = MutableOptionsFactory(
+            d=WithMeta(4, doc="option d1"),
+            e=WithMeta(5, doc="option e1"),
+            f=WithMeta(6, doc="option f1"),
+        )
+        factory = MutableOptionsFactory(
+            a=WithMeta(1, doc="option a1"),
+            b=WithMeta(2, doc="option b1"),
+            c=WithMeta(3, doc="option c1"),
+            subsection=subfactory,
+        )
+
+        factory2 = factory.add(
+            b=12,
+            c=WithMeta(13, doc="option c2"),
+            g=17,
+            subsection={"d": 14, "e": WithMeta(15, doc="option e2"), "h": 18},
+            subsection2=MutableOptionsFactory(i=WithMeta(19, doc="option i2")),
+        )
+
+        opts = factory2.create_immutable(
+            {
+                "a": 21,
+                "b": 22,
+                "c": 23,
+                "subsection": {"d": 24, "e": 25, "f": 26, "h": 27},
+                "g": 28,
+                "subsection2": {"i": 29},
+            }
+        )
+
+        assert opts.a == 21
+        assert opts.b == 22
+        assert opts.c == 23
+        assert opts.subsection.d == 24
+        assert opts.subsection.e == 25
+        assert opts.subsection.f == 26
+        assert opts.g == 28
+        assert opts.subsection.h == 27
+        assert opts.subsection2.i == 29
+
+        assert opts.doc["a"] == "option a1"
+        assert opts.doc["b"] == "option b1"
+        assert opts.doc["c"] == "option c2"
+        assert opts.doc["subsection"]["d"] == "option d1"
+        assert opts.doc["subsection"]["e"] == "option e2"
+        assert opts.doc["subsection"]["f"] == "option f1"
+        assert opts.doc["g"] is None
+        assert opts.doc["subsection"]["h"] is None
+        assert opts.doc["subsection2"]["i"] == "option i2"
+
+        with pytest.raises(ValueError, match="Passing an OptionsFactory"):
+            factory.add(a=MutableOptionsFactory(j=2))
+
+        with pytest.raises(ValueError, match="Updating the section"):
+            factory.add(subsection=MutableOptionsFactory(d=14, e=15, f=16))
 
     def test_as_table(self):
         factory = MutableOptionsFactory(a=1, b=2)

--- a/optionsfactory/tests/test_mutableoptions.py
+++ b/optionsfactory/tests/test_mutableoptions.py
@@ -337,6 +337,38 @@ class TestMutableOptions:
             opts = factory.create({"a": 3.5})
             opts.h
 
+    def test_initialise_from_options(self):
+        factory = MutableOptionsFactory(
+            a=1,
+            b=lambda options: options.a,
+            c=lambda options: options["a"],
+            d=lambda options: options.b + options.c,
+            e=WithMeta("b", value_type=int),
+            f=WithMeta(2.0, doc="option f", value_type=float, allowed=[2.0, 3.0]),
+            g=WithMeta(
+                11,
+                doc="option g",
+                value_type=int,
+                checks=[is_positive, lambda x: x < 20],
+            ),
+            h=WithMeta(
+                lambda options: options.a + 2,
+                doc="option h",
+                value_type=int,
+                checks=[is_positive, lambda x: x < 20],
+            ),
+        )
+
+        opts1 = factory.create({"a": 4, "b": 5, "f": 3.0, "g": 13, "z": 17})
+
+        opts2 = factory.create(opts1)
+
+        assert dict(opts1) == dict(opts2)
+
+        opts3 = factory.create_immutable(opts1)
+
+        assert dict(opts1) == dict(opts3)
+
     def test_circular(self):
         factory = MutableOptionsFactory(
             a=lambda options: options.b, b=lambda options: options.a,
@@ -637,6 +669,38 @@ class TestMutableOptionsFactoryImmutable:
             opts = factory.create_immutable({"a": 21})
         with pytest.raises(TypeError):
             opts = factory.create_immutable({"a": 3.5})
+
+    def test_initialise_from_options(self):
+        factory = MutableOptionsFactory(
+            a=1,
+            b=lambda options: options.a,
+            c=lambda options: options["a"],
+            d=lambda options: options.b + options.c,
+            e=WithMeta("b", value_type=int),
+            f=WithMeta(2.0, doc="option f", value_type=float, allowed=[2.0, 3.0]),
+            g=WithMeta(
+                11,
+                doc="option g",
+                value_type=int,
+                checks=[is_positive, lambda x: x < 20],
+            ),
+            h=WithMeta(
+                lambda options: options.a + 2,
+                doc="option h",
+                value_type=int,
+                checks=[is_positive, lambda x: x < 20],
+            ),
+        )
+
+        opts1 = factory.create_immutable({"a": 4, "b": 5, "f": 3.0, "g": 13, "z": 17})
+
+        opts2 = factory.create_immutable(opts1)
+
+        assert dict(opts1) == dict(opts2)
+
+        opts3 = factory.create(opts1)
+
+        assert dict(opts1) == dict(opts3)
 
     def test_circular(self):
         factory = MutableOptionsFactory(

--- a/optionsfactory/tests/test_mutableoptions.py
+++ b/optionsfactory/tests/test_mutableoptions.py
@@ -576,6 +576,37 @@ class TestMutableOptions:
         opts.a = 5
         assert opts.a == 5
 
+    def test_create_from_yaml_nested(self):
+        pytest.importorskip("yaml")
+
+        factory = MutableOptionsFactory(
+            a=1,
+            b=2,
+            subsection=MutableOptionsFactory(
+                c=3, subsubsection=MutableOptionsFactory(d=4)
+            ),
+            e=5,
+        )
+
+        with StringIO() as f:
+            f.write(
+                "a: 11\ne: 15\nsubsection:\n  c: 13\n  subsubsection:\n    d: 14\nb: 12"
+            )
+
+            # reset to beginning of f
+            f.seek(0)
+
+            opts = factory.create_from_yaml(f)
+
+        assert opts.a == 11
+        assert opts.b == 12
+        assert opts.subsection.c == 13
+        assert opts.subsection.subsubsection.d == 14
+        assert opts.e == 15
+
+        opts.a = 5
+        assert opts.a == 5
+
     def test_to_yaml(self):
         pytest.importorskip("yaml")
 
@@ -585,6 +616,32 @@ class TestMutableOptions:
         # file_like=None argument makes yaml.dump() return the YAML as a string
         assert opts.to_yaml(None) == "a: 3\n"
         assert opts.to_yaml(None, True) == "a: 3\nb: 2\n"
+
+    def test_to_yaml_nested(self):
+        pytest.importorskip("yaml")
+
+        factory = MutableOptionsFactory(
+            a=1,
+            b=2,
+            subsection=MutableOptionsFactory(
+                c=3, subsubsection=MutableOptionsFactory(d=4)
+            ),
+            e=5,
+        )
+
+        opts = factory.create(
+            {"a": 11, "subsection": {"c": 13, "subsubsection": {"d": 14}}}
+        )
+
+        assert (
+            opts.to_yaml(None)
+            == "a: 11\nsubsection:\n  c: 13\n  subsubsection:\n    d: 14\n"
+        )
+
+        assert (
+            opts.to_yaml(None, True)
+            == "a: 11\nb: 2\ne: 5\nsubsection:\n  c: 13\n  subsubsection:\n    d: 14\n"
+        )
 
     def test_nested_defaults(self):
         factory = MutableOptionsFactory(
@@ -1216,6 +1273,37 @@ class TestMutableOptionsFactoryImmutable:
         with pytest.raises(TypeError):
             opts.a = 5
 
+    def test_create_from_yaml_nested(self):
+        pytest.importorskip("yaml")
+
+        factory = MutableOptionsFactory(
+            a=1,
+            b=2,
+            subsection=MutableOptionsFactory(
+                c=3, subsubsection=MutableOptionsFactory(d=4)
+            ),
+            e=5,
+        )
+
+        with StringIO() as f:
+            f.write(
+                "a: 11\ne: 15\nsubsection:\n  c: 13\n  subsubsection:\n    d: 14\nb: 12"
+            )
+
+            # reset to beginning of f
+            f.seek(0)
+
+            opts = factory.create_immutable_from_yaml(f)
+
+        assert opts.a == 11
+        assert opts.b == 12
+        assert opts.subsection.c == 13
+        assert opts.subsection.subsubsection.d == 14
+        assert opts.e == 15
+
+        with pytest.raises(TypeError):
+            opts.a = 5
+
     def test_to_yaml(self):
         pytest.importorskip("yaml")
 
@@ -1225,6 +1313,32 @@ class TestMutableOptionsFactoryImmutable:
         # file_like=None argument makes yaml.dump() return the YAML as a string
         assert opts.to_yaml(None) == "a: 3\n"
         assert opts.to_yaml(None, True) == "a: 3\nb: 2\n"
+
+    def test_to_yaml_nested(self):
+        pytest.importorskip("yaml")
+
+        factory = MutableOptionsFactory(
+            a=1,
+            b=2,
+            subsection=MutableOptionsFactory(
+                c=3, subsubsection=MutableOptionsFactory(d=4)
+            ),
+            e=5,
+        )
+
+        opts = factory.create_immutable(
+            {"a": 11, "subsection": {"c": 13, "subsubsection": {"d": 14}}}
+        )
+
+        assert (
+            opts.to_yaml(None)
+            == "a: 11\nsubsection:\n  c: 13\n  subsubsection:\n    d: 14\n"
+        )
+
+        assert (
+            opts.to_yaml(None, True)
+            == "a: 11\nb: 2\ne: 5\nsubsection:\n  c: 13\n  subsubsection:\n    d: 14\n"
+        )
 
     def test_nested_defaults(self):
         factory = MutableOptionsFactory(

--- a/optionsfactory/tests/test_options.py
+++ b/optionsfactory/tests/test_options.py
@@ -243,6 +243,34 @@ class TestOptions:
         with pytest.raises(TypeError):
             opts = factory.create({"a": 3.5})
 
+    def test_initialise_from_options(self):
+        factory = OptionsFactory(
+            a=1,
+            b=lambda options: options.a,
+            c=lambda options: options["a"],
+            d=lambda options: options.b + options.c,
+            e=WithMeta("b", value_type=int),
+            f=WithMeta(2.0, doc="option f", value_type=float, allowed=[2.0, 3.0]),
+            g=WithMeta(
+                11,
+                doc="option g",
+                value_type=int,
+                checks=[is_positive, lambda x: x < 20],
+            ),
+            h=WithMeta(
+                lambda options: options.a + 2,
+                doc="option h",
+                value_type=int,
+                checks=[is_positive, lambda x: x < 20],
+            ),
+        )
+
+        opts1 = factory.create({"a": 4, "b": 5, "f": 3.0, "g": 13, "z": 17})
+
+        opts2 = factory.create(opts1)
+
+        assert dict(opts1) == dict(opts2)
+
     def test_circular(self):
         factory = OptionsFactory(
             a=lambda options: options.b, b=lambda options: options.a,

--- a/optionsfactory/tests/test_options.py
+++ b/optionsfactory/tests/test_options.py
@@ -136,7 +136,6 @@ class TestOptions:
             ),
         )
 
-        # test default values
         opts = factory.create({"a": 4, "b": 5, "f": 3.0, "g": 13, "z": 17})
 
         assert opts.a == 4


### PR DESCRIPTION
Allow the creation of nested `OptionsFactory` or `MutableOptionsFactory` objects, which can create nested trees of `Options` or `MutableOptions`.