### PR TITLE
Allow using values from parent sections when evaluating expressions

### DIFF
--- a/optionsfactory/optionsfactory.py
+++ b/optionsfactory/optionsfactory.py
@@ -235,6 +235,10 @@ class OptionsFactory:
         def doc(self):
             return self.__doc
 
+        @property
+        def parent(self):
+            return self.__parent
+
         def as_table(self):
             """Return a string with a formatted table of the settings
             """
@@ -292,9 +296,16 @@ class OptionsFactory:
                 if value is None:
                     yield key
 
-        def __clear_cache(self):
-            self.__cache = {}
-            if self.__parent is not None:
+        def __clear_cache(self, is_child=False):
+            if self.__parent is None or is_child:
+                # Once we have found the root MutableOptions object, follow the tree,
+                # clearing the cache of each MutableOptions section or subsection.
+                self.__cache = {}
+                for subsection in self.get_subsections():
+                    self[subsection].__clear_cache(True)
+            else:
+                # Go up until we find the root MutableOptions object, which has
+                # (self.parent is None)
                 self.__parent.__clear_cache()
 
         def __getitem__(self, key):

--- a/optionsfactory/tests/test_mutableoptions.py
+++ b/optionsfactory/tests/test_mutableoptions.py
@@ -369,6 +369,32 @@ class TestMutableOptions:
 
         assert dict(opts1) == dict(opts3)
 
+    def test_nested_from_parent(self):
+        factory = MutableOptionsFactory(
+            a=1,
+            subsection=MutableOptionsFactory(
+                b=2, c=lambda options: options.b + options.parent.a
+            ),
+        )
+
+        opts = factory.create({})
+
+        assert opts.a == 1
+        assert opts.subsection.b == 2
+        assert opts.subsection.c == 3
+
+        opts.a = 6
+
+        assert opts.a == 6
+        assert opts.subsection.b == 2
+        assert opts.subsection.c == 8
+
+        opts2 = factory.create({"a": 4})
+
+        assert opts2.a == 4
+        assert opts2.subsection.b == 2
+        assert opts2.subsection.c == 6
+
     def test_values_nested(self):
         factory = MutableOptionsFactory(a=1, subsection=MutableOptionsFactory(b=2), c=3)
         opts = factory.create({})
@@ -1072,6 +1098,26 @@ class TestMutableOptionsFactoryImmutable:
         opts3 = factory.create(opts1)
 
         assert dict(opts1) == dict(opts3)
+
+    def test_nested_from_parent(self):
+        factory = MutableOptionsFactory(
+            a=1,
+            subsection=MutableOptionsFactory(
+                b=2, c=lambda options: options.b + options.parent.a
+            ),
+        )
+
+        opts = factory.create_immutable({})
+
+        assert opts.a == 1
+        assert opts.subsection.b == 2
+        assert opts.subsection.c == 3
+
+        opts2 = factory.create_immutable({"a": 4})
+
+        assert opts2.a == 4
+        assert opts2.subsection.b == 2
+        assert opts2.subsection.c == 6
 
     def test_values_nested(self):
         factory = MutableOptionsFactory(a=1, subsection=MutableOptionsFactory(b=2), c=3)

--- a/optionsfactory/tests/test_options.py
+++ b/optionsfactory/tests/test_options.py
@@ -292,6 +292,26 @@ class TestOptions:
 
         assert dict(opts1) == dict(opts2)
 
+    def test_nested_from_parent(self):
+        factory = OptionsFactory(
+            a=1,
+            subsection=OptionsFactory(
+                b=2, c=lambda options: options.b + options.parent.a
+            ),
+        )
+
+        opts = factory.create({})
+
+        assert opts.a == 1
+        assert opts.subsection.b == 2
+        assert opts.subsection.c == 3
+
+        opts2 = factory.create({"a": 4})
+
+        assert opts2.a == 4
+        assert opts2.subsection.b == 2
+        assert opts2.subsection.c == 6
+
     def test_values_nested(self):
         factory = OptionsFactory(a=1, subsection=OptionsFactory(b=2), c=3)
         opts = factory.create({})


### PR DESCRIPTION
Adds a `parent` `@property` to `MutableOptions`, which allows expressions
like:
```
c=lambda options: options.b + options.parent.a
```