### PR TITLE
Replace 'checks' with 'check_all' and add 'check_any'

### DIFF
--- a/optionsfactory/_utils.py
+++ b/optionsfactory/_utils.py
@@ -16,14 +16,26 @@ def _checked(value, *, meta=None, name=None):
                 f"{'' if name is None else ' for key=' + str(name)}"
             )
 
-    if meta.checks is not None:
-        for check in meta.checks:
+    if meta.check_all is not None:
+        for check in meta.check_all:
             if not check(value):
                 raise ValueError(
                     f"The value {value}"
                     f"{'' if name is None else ' of key=' + str(name)} is not "
-                    f"compatible with the checks"
+                    f"compatible with check_all"
                 )
+
+    if meta.check_any is not None:
+        success = False
+        for check in meta.check_any:
+            if check(value):
+                success = True
+        if not success:
+            raise ValueError(
+                f"The value {value}"
+                f"{'' if name is None else ' of key=' + str(name)} is not "
+                f"compatible with check_any"
+            )
 
     return value
 

--- a/optionsfactory/checks.py
+++ b/optionsfactory/checks.py
@@ -3,7 +3,10 @@
 
 
 def is_positive(x):
-    return x > 0
+    try:
+        return x > 0
+    except TypeError:
+        return False
 
 
 def is_positive_or_None(x):
@@ -13,13 +16,20 @@ def is_positive_or_None(x):
 
 
 def is_non_negative(x):
-    return x >= 0
+    try:
+        return x >= 0
+    except TypeError:
+        return False
 
 
 def is_non_negative_or_None(x):
     if x is None:
         return True
     return is_non_negative(x)
+
+
+def is_None(x):
+    return x is None
 
 
 NoneType = type(None)

--- a/optionsfactory/tests/test_check_utilities.py
+++ b/optionsfactory/tests/test_check_utilities.py
@@ -1,10 +1,9 @@
-import pytest
-
 from ..checks import (
     is_positive,
     is_positive_or_None,
     is_non_negative,
     is_non_negative_or_None,
+    is_None,
 )
 
 
@@ -13,8 +12,7 @@ class TestValueCheckUtilities:
         assert is_positive(1)
         assert not is_positive(-1)
         assert not is_positive(0.0)
-        with pytest.raises(TypeError):
-            is_positive(None)
+        assert not is_positive(None)
 
     def test_is_positive_or_None(self):
         assert is_positive_or_None(1)
@@ -26,11 +24,16 @@ class TestValueCheckUtilities:
         assert is_non_negative(1)
         assert not is_non_negative(-1)
         assert is_non_negative(0.0)
-        with pytest.raises(TypeError):
-            is_non_negative(None)
+        assert not is_non_negative(None)
 
     def test_is_non_negative_or_None(self):
         assert is_non_negative_or_None(1)
         assert not is_non_negative_or_None(-1)
         assert is_non_negative_or_None(0.0)
         assert is_non_negative_or_None(None)
+
+    def test_is_None(self):
+        assert is_None(None)
+        assert not is_None(3.0)
+        assert not is_None(-1)
+        assert not is_None("foo")

--- a/optionsfactory/tests/test_mutableoptions.py
+++ b/optionsfactory/tests/test_mutableoptions.py
@@ -21,13 +21,13 @@ class TestMutableOptions:
                 11,
                 doc="option g",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_all=[is_positive, lambda x: x < 20],
             ),
             h=WithMeta(
                 lambda options: options.a + 2,
                 doc="option h",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_any=[is_positive, lambda x: x < -20],
             ),
         )
 
@@ -192,13 +192,13 @@ class TestMutableOptions:
                 11,
                 doc="option g",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_all=[is_positive, lambda x: x < 20],
             ),
             h=WithMeta(
                 lambda options: options.a + 2,
                 doc="option h",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_any=[is_positive, lambda x: x < -20],
             ),
         )
 
@@ -323,16 +323,14 @@ class TestMutableOptions:
             opts = factory.create({"g": 3.5})
         with pytest.raises(ValueError):
             opts = factory.create({"h": -7})
-        with pytest.raises(ValueError):
-            opts = factory.create({"h": 21})
+        assert factory.create({"h": -21}).h == -21
         with pytest.raises(TypeError):
             opts = factory.create({"h": 3.5})
         with pytest.raises(ValueError):
             opts = factory.create({"a": -7})
             opts.h
-        with pytest.raises(ValueError):
-            opts = factory.create({"a": 21})
-            opts.h
+        opts = factory.create({"a": -23})
+        assert opts.h == -21
         with pytest.raises(TypeError):
             opts = factory.create({"a": 3.5})
             opts.h
@@ -349,13 +347,13 @@ class TestMutableOptions:
                 11,
                 doc="option g",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_all=[is_positive, lambda x: x < 20],
             ),
             h=WithMeta(
                 lambda options: options.a + 2,
                 doc="option h",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_any=[is_positive, lambda x: x < -20],
             ),
         )
 
@@ -853,13 +851,13 @@ class TestMutableOptionsFactoryImmutable:
                 11,
                 doc="option g",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_all=[is_positive, lambda x: x < 20],
             ),
             h=WithMeta(
                 lambda options: options.a + 2,
                 doc="option h",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_any=[is_positive, lambda x: x < -20],
             ),
         )
 
@@ -950,13 +948,13 @@ class TestMutableOptionsFactoryImmutable:
                 11,
                 doc="option g",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_all=[is_positive, lambda x: x < 20],
             ),
             h=WithMeta(
                 lambda options: options.a + 2,
                 doc="option h",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_any=[is_positive, lambda x: x < -20],
             ),
         )
 
@@ -1056,14 +1054,12 @@ class TestMutableOptionsFactoryImmutable:
             opts = factory.create_immutable({"g": 3.5})
         with pytest.raises(ValueError):
             opts = factory.create_immutable({"h": -7})
-        with pytest.raises(ValueError):
-            opts = factory.create_immutable({"h": 21})
+        assert factory.create_immutable({"h": -21}).h == -21
         with pytest.raises(TypeError):
             opts = factory.create_immutable({"h": 3.5})
         with pytest.raises(ValueError):
             opts = factory.create_immutable({"a": -7})
-        with pytest.raises(ValueError):
-            opts = factory.create_immutable({"a": 21})
+        assert factory.create_immutable({"a": -23}).h == -21
         with pytest.raises(TypeError):
             opts = factory.create_immutable({"a": 3.5})
 
@@ -1079,13 +1075,13 @@ class TestMutableOptionsFactoryImmutable:
                 11,
                 doc="option g",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_all=[is_positive, lambda x: x < 20],
             ),
             h=WithMeta(
                 lambda options: options.a + 2,
                 doc="option h",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_any=[is_positive, lambda x: x < -20],
             ),
         )
 

--- a/optionsfactory/tests/test_options.py
+++ b/optionsfactory/tests/test_options.py
@@ -50,13 +50,13 @@ class TestOptions:
                 11,
                 doc="option g",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_all=[is_positive, lambda x: x < 20],
             ),
             h=WithMeta(
                 lambda options: options.a + 2,
                 doc="option h",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_any=[is_positive, lambda x: x < -20],
             ),
         )
 
@@ -147,13 +147,13 @@ class TestOptions:
                 11,
                 doc="option g",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_all=[is_positive, lambda x: x < 20],
             ),
             h=WithMeta(
                 lambda options: options.a + 2,
                 doc="option h",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_any=[is_positive, lambda x: x < -20],
             ),
         )
 
@@ -253,14 +253,12 @@ class TestOptions:
             opts = factory.create({"g": 3.5})
         with pytest.raises(ValueError):
             opts = factory.create({"h": -7})
-        with pytest.raises(ValueError):
-            opts = factory.create({"h": 21})
+        assert factory.create({"h": -21}).h == -21
         with pytest.raises(TypeError):
             opts = factory.create({"h": 3.5})
         with pytest.raises(ValueError):
             opts = factory.create({"a": -7})
-        with pytest.raises(ValueError):
-            opts = factory.create({"a": 21})
+        assert factory.create({"a": -23}).h == -21
         with pytest.raises(TypeError):
             opts = factory.create({"a": 3.5})
 
@@ -276,13 +274,13 @@ class TestOptions:
                 11,
                 doc="option g",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_all=[is_positive, lambda x: x < 20],
             ),
             h=WithMeta(
                 lambda options: options.a + 2,
                 doc="option h",
                 value_type=int,
-                checks=[is_positive, lambda x: x < 20],
+                check_any=[is_positive, lambda x: x < -20],
             ),
         )
 


### PR DESCRIPTION
For convenience allow either or both of `check_all` or `check_any`, instead of just `checks` when constructing `WithMeta` objects. Allows some combinations to be expressed more compactly, e.g. `check_any=[lambda x: isinstance(x, int), is_positive]` rather than `checks=lambda x: (isinstance(x, int)) or is_positive(x))`.