### PR TITLE
Upgrade setuptools when publishing to PyPi

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install --upgrade setuptools wheel twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
Need a new version of setuptools to use the 'license_files' option, so pass `--upgrade` to `pip install --upgrade setuptools wheel twine` in the `pythonpublish.yml` recipe.