### PR TITLE
Need to fetch full repo with tags to get version for publishing

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -101,5 +101,6 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
+        git fetch --tags --unshallow
         python setup.py sdist bdist_wheel
         twine upload dist/*


### PR DESCRIPTION
Versioneer relies on tags to create a version number. That means we need the git repo to include tags. Github's checkout action changed to a shallow checkout with only the latest commit, which does not have tags. Easiest (maybe not only) fix is to do a 'git fetch --tags --unshallow' to get a full copy of the repo with tags.