### PR TITLE
Fix pickling with dill

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest
+        pip install pytest dill
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest
+        pip install pytest dill
     - name: Test with pytest
       run: |
         pytest

--- a/README.md
+++ b/README.md
@@ -175,8 +175,9 @@ with the documentation for each option:
 
 ### `value_type`
 
-The value_type argument can be used to give a type or sequence of types that the option
-is allowed to have. Trying to set an option with a non-allowed type raises a
+The `value_type` argument can be used to give a type or sequence of types that
+the option is allowed to have. Trying to set an option with a non-allowed type
+raises a
 `ValueError`:
 ```python
 >>> d2 = D(d=-2)
@@ -385,6 +386,12 @@ or all values including defaults, by passing `True` to the `with_defaults` argum
 >>> with open(filename, 'w') as f:
 >>>     options.to_yaml(f, True)  # saves options with default values as well
 ```
+
+
+### Pickling (with dill)
+
+`Options` objects can be pickled using `dill`. This is tested. Pickling of
+`MutableOptions` objects is not currently supported.
 
 
 Examples

--- a/optionsfactory/optionsfactory.py
+++ b/optionsfactory/optionsfactory.py
@@ -5,9 +5,7 @@ from .withmeta import WithMeta
 
 
 class OptionsFactory:
-    """Factory to create Options instances
-
-    """
+    """Factory to create Options instances"""
 
     def __init__(self, *args, **kwargs):
         """Define the members of Options instances that this factory will create
@@ -81,16 +79,12 @@ class OptionsFactory:
 
     @property
     def defaults(self):
-        """Get the default values defined for this OptionsFactory
-
-        """
+        """Get the default values defined for this OptionsFactory"""
         return deepcopy(self.__defaults)
 
     @property
     def doc(self):
-        """Get the documentation for the options defined for this OptionsFactory
-
-        """
+        """Get the documentation for the options defined for this OptionsFactory"""
         return {key: value.doc for key, value in self.__defaults.items()}
 
     def add(self, **kwargs):
@@ -246,8 +240,7 @@ class OptionsFactory:
             return self.__parent
 
         def as_table(self):
-            """Return a string with a formatted table of the settings
-            """
+            """Return a string with a formatted table of the settings"""
             return _options_table_string(self)
 
         def to_dict(self, with_defaults=True):
@@ -475,8 +468,7 @@ class OptionsFactory:
             return deepcopy(self.__doc)
 
         def as_table(self):
-            """Return a string with a formatted table of the settings
-            """
+            """Return a string with a formatted table of the settings"""
             return _options_table_string(self)
 
         def to_dict(self, with_defaults=True):
@@ -598,9 +590,7 @@ class OptionsFactory:
 
 
 class MutableOptionsFactory(OptionsFactory):
-    """Factory to create MutableOptions or Options instances
-
-    """
+    """Factory to create MutableOptions or Options instances"""
 
     def create(self, values=None):
         """Create a MutableOptions instance

--- a/optionsfactory/optionsfactory.py
+++ b/optionsfactory/optionsfactory.py
@@ -546,6 +546,14 @@ class OptionsFactory:
                 raise TypeError("Options does not allow assigning to attributes")
             super(OptionsFactory.Options, self).__setattr__(key, value)
 
+        def __getstate__(self):
+            # Need to define this so that pickling with dill works
+            return vars(self)
+
+        def __setstate__(self, state):
+            # Need to define this so that pickling with dill works
+            vars(self).update(state)
+
         def is_default(self, key):
             try:
                 return self.__is_default[key]

--- a/optionsfactory/tests/test_mutableoptions.py
+++ b/optionsfactory/tests/test_mutableoptions.py
@@ -414,7 +414,8 @@ class TestMutableOptions:
 
     def test_circular(self):
         factory = MutableOptionsFactory(
-            a=lambda options: options.b, b=lambda options: options.a,
+            a=lambda options: options.b,
+            b=lambda options: options.a,
         )
         opts = factory.create()
         with pytest.raises(ValueError, match="Circular definition"):
@@ -1136,7 +1137,8 @@ class TestMutableOptionsFactoryImmutable:
 
     def test_circular(self):
         factory = MutableOptionsFactory(
-            a=lambda options: options.b, b=lambda options: options.a,
+            a=lambda options: options.b,
+            b=lambda options: options.a,
         )
         with pytest.raises(ValueError, match="Circular definition"):
             opts = factory.create_immutable()

--- a/optionsfactory/tests/test_options.py
+++ b/optionsfactory/tests/test_options.py
@@ -708,3 +708,13 @@ class TestOptions:
         assert opts.doc["subsection2"]["e"] is None
         assert opts.subsection2.subsubsection.doc["f"] == "option f"
         assert opts.subsection3.doc["z"] == "option z"
+
+    def test_dill_pickling(self):
+        import dill
+
+        factory = OptionsFactory(foo="bar")
+        options = factory.create()
+        pickled = dill.dumps(options)
+        unpickled = dill.loads(pickled, ignore=True)
+
+        assert unpickled.foo == "bar"

--- a/optionsfactory/tests/test_options.py
+++ b/optionsfactory/tests/test_options.py
@@ -331,7 +331,8 @@ class TestOptions:
 
     def test_circular(self):
         factory = OptionsFactory(
-            a=lambda options: options.b, b=lambda options: options.a,
+            a=lambda options: options.b,
+            b=lambda options: options.a,
         )
         with pytest.raises(ValueError, match="Circular definition"):
             opts = factory.create()
@@ -483,7 +484,9 @@ class TestOptions:
 
     def test_str_nested(self):
         factory = OptionsFactory(
-            a=1, subsection=OptionsFactory(c=3, subsubsection=OptionsFactory(d=4)), b=2,
+            a=1,
+            subsection=OptionsFactory(c=3, subsubsection=OptionsFactory(d=4)),
+            b=2,
         )
         opts = factory.create({"b": 5, "subsection": {"subsubsection": {"d": 6}}})
         assert (

--- a/optionsfactory/tests/test_withmeta.py
+++ b/optionsfactory/tests/test_withmeta.py
@@ -150,7 +150,9 @@ class TestWithMeta:
 
     def test_combined_check_all_any(self):
         x = WithMeta(
-            5.0, check_all=is_positive, check_any=[lambda x: x < 10.0, is_None],
+            5.0,
+            check_all=is_positive,
+            check_any=[lambda x: x < 10.0, is_None],
         )
         assert x.evaluate_expression({}) == 5.0
         x.value = -2.0

--- a/optionsfactory/withmeta.py
+++ b/optionsfactory/withmeta.py
@@ -4,9 +4,7 @@ from ._utils import _checked
 
 
 class WithMeta:
-    """Type for passing metadata with options value or expression into OptionsFactory
-
-    """
+    """Type for passing metadata with options value or expression into OptionsFactory"""
 
     def __init__(
         self,

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setuptools.setup(
         "checking"
     ),
     extras_require={"yaml": "PyYAML>=5.1"},
+    tests_require=["dill>=0.3.0"],
     license="OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Latest versions of dill introduced issue which caused pickling of `Options` objects to fail. Fixed by defining `__getstate__()` and `__setstate__()` methods as suggested here https://stackoverflow.com/a/50888571.