### PR TITLE
Set format of all columns to 'text' in get_help_table()

### DIFF
--- a/optionsfactory/optionsfactory.py
+++ b/optionsfactory/optionsfactory.py
@@ -242,6 +242,7 @@ class OptionsFactory:
                 raise
             tt = Texttable()
             tt.header([heading1, heading2, heading3])
+            tt.set_cols_dtype(["t", "t", "t"])
             for k in keys:
                 tt.add_row([k, str(docs[k]), str(evaluated_defaults[k])])
             return tt


### PR DESCRIPTION
Ensures that texttable does not mess around with already-formatted strings, e.g. before this commit it would print '2e-8' as '0.000'.